### PR TITLE
Simpler load refactor

### DIFF
--- a/plugs/app/page/dark-crystal.mcss
+++ b/plugs/app/page/dark-crystal.mcss
@@ -15,7 +15,7 @@ DarkCrystal {
     font-size: 1.2rem
 
     i {
-      margin-left: .9rem }
+      margin-left: .9rem
       :hover {
         color: rebeccapurple
         cursor: pointer

--- a/views/component/recipient.js
+++ b/views/component/recipient.js
@@ -1,11 +1,12 @@
+const { h } = require('mutant')
+
 module.exports = function Recipient ({ recp, avatar }) {
   if (typeof recp === 'string') { // assume it's myId
-    return h('div.recp', [ avatar(recp, 'tiny') ])
+    return h('Recipient', [ avatar(recp, 'tiny') ])
   }
 
-  return h('div.recp', [
+  return h('Recipient', [
     avatar(recp.link, 'tiny'),
     h('div.name', recp.name)
   ])
 }
-

--- a/views/requests/new.js
+++ b/views/requests/new.js
@@ -1,12 +1,19 @@
-const pull = require('pull-stream')
-const { h, Value } = require('mutant')
+const { h, Value, when } = require('mutant')
 
-module.exports = function DarkCrystalRequestNew ({ root, scuttle, modal, state, recps }) {
+module.exports = function DarkCrystalRequestNew ({ root, scuttle, modal, recipients = null }, callback) {
+  // if recipients is null, then all shard holders get a request!
   const rootId = root.key
-  const warning = Value(false)
+  const requesting = Value(false)
+  const warningOpen = Value(false)
 
   return h('div.request', [
-    h('button -primary', { 'ev-click': (e) => warning.set(true) }, 'Request'),
+    h('button -primary',
+      { 'ev-click': (e) => warningOpen.set(true) },
+      when(requesting,
+        h('i.fa.fa-spinner.fa-pulse'),
+        'Request'
+      )
+    ),
     warningModal()
   ])
 
@@ -14,23 +21,21 @@ module.exports = function DarkCrystalRequestNew ({ root, scuttle, modal, state, 
     return modal(
       h('div.warning', [
         h('span', 'Are you sure?'),
-        h('button -subtle', { 'ev-click': () => warning.set(false) }, 'Cancel'),
-        h('button -subtle', { 'ev-click': sendRequest }, 'OK'),
-      ]), { isOpen: warning }
+        h('button -subtle', { 'ev-click': () => warningOpen.set(false) }, 'Cancel'),
+        h('button -subtle', { 'ev-click': sendRequest }, 'OK')
+      ]), { isOpen: warningOpen }
     )
   }
 
   function sendRequest () {
-    state.requesting.set(true)
-    scuttle.recover.async.request(rootId, recps, (err, requests) => {
-      if (err) {
-        state.requesting.set(false)
-        // render an error
-      } else {
-        state.requested.set(true)
-        state.requesting.set(false)
-        warning.set(false)
-      }
+    warningOpen.set(false)
+    requesting.set(true)
+
+    scuttle.recover.async.request(rootId, recipients, (err, requests) => {
+      requesting.set(false)
+      if (err) return callback(err)
+
+      callback(null, requests)
     })
   }
 }

--- a/views/requests/new.js
+++ b/views/requests/new.js
@@ -7,7 +7,7 @@ module.exports = function DarkCrystalRequestNew ({ root, scuttle, modal, recipie
   const warningOpen = Value(false)
 
   return h('div.request', [
-    h('button -primary',
+    h('button',
       { 'ev-click': (e) => warningOpen.set(true) },
       when(requesting,
         h('i.fa.fa-spinner.fa-pulse'),

--- a/views/rituals/show.js
+++ b/views/rituals/show.js
@@ -1,18 +1,14 @@
-const pull = require('pull-stream')
-const { h } = require('mutant')
+const { h, computed } = require('mutant')
+const getContent = require('ssb-msg-content')
 
-module.exports = function DarkCrystalRitualShow ({ scuttle, msg }) {
-  const {
-    value: {
-      timestamp,
-      content: {
-        quorum,
-        shards
-      }
-    }
-  } = msg
+module.exports = function DarkCrystalRitualShow (msg) {
+  return computed(msg, msg => {
+    if (!msg) return
 
-  return h('section.ritual', [
-    h('p', `Quorum required to reassemble: ${quorum}`)
-  ])
+    const { quorum } = getContent(msg)
+
+    return h('section.ritual', [
+      h('p', `Quorum required to reassemble: ${quorum}`)
+    ])
+  })
 }

--- a/views/shards/record.js
+++ b/views/shards/record.js
@@ -16,11 +16,17 @@ module.exports = function DarkCrystalShardShow ({ root, record, scuttle, modal, 
     Recipient({ recp, avatar }),
     Timestamp({ prefix: 'Shard sent on', timestamp: shard.value.timestamp }),
     recoveryHistory.map(msg => {
-      return h('div', [ // WORSE IS BETTER (i.e. anyone can improve this!)
-        getContent(msg).type,
+      const { type, body } = getContent(msg)
+      var icon = type === 'invite'
+        ? h('i.fa.fa-question-circle', { title: type })
+        : type === 'invite-reply' ? h('i.fa.fa-puzzle-piece', { title: type }) : ''
+
+      return h('div.historyItem', [
+        icon,
         ' - ',
-        getContent(msg).body,
-        Timestamp({ timestamp: msg.value.timestamp })
+        Timestamp({ timestamp: msg.value.timestamp }),
+        ' - ',
+        body
       ])
     }),
     DarkCrystalRequestNew({ root, scuttle, modal, recipients: [recp] }, console.log)

--- a/views/shards/record.js
+++ b/views/shards/record.js
@@ -1,0 +1,34 @@
+const { h } = require('mutant')
+const getContent = require('ssb-msg-content')
+const sort = require('ssb-sort')
+
+const Recipient = require('../component/recipient')
+const Timestamp = require('../component/timestamp')
+const DarkCrystalRequestNew = require('../requests/new')
+
+module.exports = function DarkCrystalShardShow ({ root, record, scuttle, modal, avatar, msg }) {
+  const { shard, requests, replies } = record
+
+  const recp = getRecp(shard)
+  const recoveryHistory = sort([...requests, ...replies])
+
+  return h('div.ShardRecord', [
+    Recipient({ recp, avatar }),
+    Timestamp({ prefix: 'Shard sent on', timestamp: shard.value.timestamp }),
+    recoveryHistory.map(msg => {
+      return h('div', [ // WORSE IS BETTER (i.e. anyone can improve this!)
+        getContent(msg).type,
+        ' - ',
+        getContent(msg).body,
+        Timestamp({ timestamp: msg.value.timestamp })
+      ])
+    }),
+    DarkCrystalRequestNew({ root, scuttle, modal, recipients: [recp] }, console.log)
+  ])
+}
+
+// TODO extract this into a scuttle-dc method if we use it a lot
+function getRecp (shard) {
+  return getContent(shard).recps
+    .find(r => r !== shard.value.author)
+}

--- a/views/shards/record.mcss
+++ b/views/shards/record.mcss
@@ -1,0 +1,16 @@
+ShardRecord {
+  display: grid
+  grid-template-columns: auto auto
+  grid-gap: .5rem
+  justify-content: start
+  align-content: start
+
+  div {
+    grid-column: 2
+  }
+
+  div.Recipient {
+    grid-column: 1
+    grid-row: 1 / 3
+  }
+}

--- a/views/shards/record.mcss
+++ b/views/shards/record.mcss
@@ -5,12 +5,19 @@ ShardRecord {
   justify-content: start
   align-content: start
 
-  div {
-    grid-column: 2
-  }
-
   div.Recipient {
     grid-column: 1
     grid-row: 1 / 3
+  }
+
+  div.historyItem {
+    grid-column: 2
+
+    display: flex
+    align-items: center
+  }
+
+  div.request {
+    grid-column: 2
   }
 }

--- a/views/show.js
+++ b/views/show.js
@@ -1,202 +1,85 @@
 const pull = require('pull-stream')
-const { h, Array: MutantArray, map, resolve, computed, Value, when, Struct } = require('mutant')
+const { h, Array: MutantArray, computed, Value, Struct } = require('mutant')
+const getContent = require('ssb-msg-content')
 
 const isRitual = require('scuttle-dark-crystal/isRitual')
 const isShard = require('scuttle-dark-crystal/isShard')
 const { isInvite, isReply } = require('ssb-invite-schema')
 
-const DarkCrystalRequestNew = require('./requests/new')
-const DarkCrystalRequestShow = require('./requests/show')
 const DarkCrystalRitualShow = require('./rituals/show')
-const DarkCrystalShardShow = require('./shards/show')
+const DarkCrystalShardRecord = require('./shards/record')
 
 function DarkCrystalShow ({ root, scuttle, avatar, modal }) {
   const rootId = root.key
 
   const store = Struct({
+    ready: Value(false),
     ritual: Value(),
-    shards: MutantArray([]),
-    requests: MutantArray([]),
-    replies: MutantArray([])
+    shardRecords: MutantArray([])
   })
 
-  pull(
-    scuttle.root.pull.backlinks(rootId, { live: true }),
-    pull.filter(m => !m.sync),
-    pull.drain(msg => {
-      match(msg)
-        .on(isRitual, ritual => store.ritual.set(ritual))
-        .on(isShard, shard => store.shards.push(shard))
-        .on(isInvite, request => store.requests.push(request))
-        .on(isReply, reply => store.replies.push(reply))
-    })
-  )
+  updateStore()
+  watchForUpdates()
 
   return h('DarkCrystalShow', [
-    computed([store.ritual], (msg) => msg ? DarkCrystalRitualShow({ scuttle, msg }) : null),
-    h('section.shards', map(
-      store.shards,
-      (msg) => DarkCrystalShardShow({ root, scuttle, modal, avatar, msg: msg }),
-      { comparer }
-    )),
-    h('section.requests', map(
-      store.requests,
-      (msg) => DarkCrystalRequestShow({ root, scuttle, msg: msg }),
-      { comparer }
-    )),
-    h('section.replies', map(
-      store.replies,
-      (msg) => h('Reply', reply),
-      { comparer }
-    ))
-    // How can we blend the shards and requests (and replies) datasets & sections?
-    // Requires mapping store.shards onto store.requests
-    // But MutantArray([]).find is not a function despite documentation
-    // Need to somehow match shard.recps against request.recps (and reply.recps next)
-    // while they're still observables
+    DarkCrystalRitualShow(store.ritual),
+    h('section.shards', computed(store.shardRecords, records => {
+      return records.map(record => {
+        return DarkCrystalShardRecord({ root, record, scuttle, modal, avatar })
+      })
+    }))
   ])
-}
 
-function comparer (a, b) {
-  return a && b && a.key === b.key
-}
+  function updateStore () {
+    pull(
+      scuttle.root.pull.backlinks(rootId, { live: false }),
+      pull.collect(
+        (err, msgs) => {
+          if (err) throw err
 
-function matched (x) {
-  return {
-    on: () => matched(x),
-    otherwise: () => x,
+          const ritual = msgs.find(isRitual)
+          store.ritual.set(ritual)
+
+          // recorvery is a "dialogue" between you and each friend
+          // gather all messages related to each dialogue into a "record" of form { root, shard, requests, replies }
+          const shardRecords = msgs
+            .filter(isShard)
+            .map(shard => {
+              const dialogueMsgs = getDialgogue(shard, msgs)
+
+              return {
+                shard,
+                requests: dialogueMsgs.filter(isInvite),
+                replies: dialogueMsgs.filter(isReply)
+              }
+            })
+          store.shardRecords.set(shardRecords)
+        },
+        () => store.ready.set(true)
+      )
+    )
+  }
+
+  function watchForUpdates () {
+    // when any new messages come int related to this root, just get all the data again and write over it.
+    // triggering a big render of who page... 
+    pull(
+      scuttle.root.pull.backlinks(rootId, { live: true, old: false }), // old: false means start from now on
+      pull.filter(m => !m.sync),
+      // pull.through(m => console.log('NEW MSG! update the page!!!', m)),
+      pull.drain(m => updateStore())
+    )
   }
 }
 
-function match (x) {
-  return {
-    on: (pred, fn) => pred(x) ? matched(fn(x)) : match(x),
-    otherwise: fn => fn(x),
-  }
+function getDialgogue (shard, msgs) {
+  const dialogueKey = recpsKey(shard)
+
+  return msgs.filter(msg => recpsKey(msg) === dialogueKey)
+}
+function recpsKey (msg) {
+  // a 'dialogue' can be determined by the recps in that dialogue
+  return getContent(msg).recps.sort().join('')
 }
 
 module.exports = DarkCrystalShow
-
-// function Shard (shard) {
-//   const {
-//     // request,
-//     value: {
-//       timestamp,
-//       content: {
-//         recps = []
-//       }
-//     }
-//   } = shard
-
-//   // MutantArray().find doesnt exist?! Despite documentation
-//   const request = store.requests.find(r => {
-//     console.log(r)
-//     console.log(recps)
-//     return r.value.content.recps.sort() === recps.sort()
-//   })
-//   console.log(request)
-
-//   // const state = Struct({
-//   //   requested: Boolean(request),
-//   //   showWarning: false
-//   // })
-
-//   // const requested = computed([state.requested], Boolean)
-
-//   return h('div.shard', [
-//     h('div.overview', [
-//       Recipient({ recp: recps[0], avatar }),
-//       Timestamp({ prefix: 'Sent on', timestamp }),
-//     ])
-//   ])
-// }
-
-// when(
-//   requested(),
-//   DarkCrystalRequestShow({
-//     scuttle,
-//     modal,
-//     request
-//   }),
-//   DarkCrystalRequestNew({
-//     root,
-//     scuttle,
-//     modal,
-//     recps,
-//     state
-//   })
-// )
-
-// function getBacklinks () {
-//   const store = Struct({
-//     ritual: Value(),
-//     shards: MutantArray([]),
-//     requests: MutantArray([]),
-//     replies: MutantArray([])
-//   })
-
-//   pull(
-//     scuttle.root.pull.backlinks(rootId, { live: true }),
-//     pull.filter(m => !m.sync),
-//     pull.drain(msg => {
-//       match(msg)
-//         .on(isRitual, ritual => store.ritual.set(ritual))
-//         .on(isShard, shard => store.shards.push(shard))
-//         .on(isInvite, request => store.requests.push(request))
-//         .on(isReply, reply => store.replies.push(reply))
-//     })
-//   )
-
-//   return store
-// }
-
-// function getShards () {
-//   const store = MutantArray([])
-//   pull(
-//     scuttle.shard.pull.byRoot(rootId, { live: true }),
-//     pull.filter(m => !m.sync),
-//     pull.through(shard => pageState.hasShards.set(true)),
-//     pull.asyncMap((shard, callback) => {
-//       pull(
-//         scuttle.recover.pull.requests(rootId),
-//         pull.filter(m => !m.sync),
-//         pull.through(request => resolve(pageState.requested) ? null : pageState.requested.set(true)),
-//         pull.through(request => console.log(pageState.requested())),
-//         pull.take(1),
-//         pull.drain(request => {
-//           shard.request = request
-//           callback(null, shard)
-//         }, () => {
-//           callback(null, shard)
-//         })
-//       )
-//     }),
-//     pull.drain(shard => store.push(shard))
-//   )
-//   return store
-// }
-
-// function ProgressBar(ritual) {
-//   const { quorum } = getContent(ritual)
-//   return h('progress', { 'style': { 'margin-left': '10px' }, min: 0, max: 1, value: (getReplies().getLength() / quorum) })
-// }
-
-// function getReplies () {
-  //   var store = MutantArray([])
-  //   pull(
-//     scuttle.recover.pull.replies(rootId, { live: true }),
-  //     pull.filter(m => !m.sync),
-//     pull.drain(reply => store.push(reply))
-//   )
-//   return store
-// }
-
-// function getRitual () {
-  //   const store = MutantArray([])
-//   pull(
-//     scuttle.ritual.pull.byRoot(rootId, { live: true }),
-//     pull.filter(m => !m.sync),
-//     pull.drain(ritual => store.push(ritual))
-//   )
-//   return store
-// }

--- a/views/show.mcss
+++ b/views/show.mcss
@@ -7,6 +7,6 @@ DarkCrystalShow {
 
   section.shards {
     display: grid
-    grid-gap: 1rem
+    grid-gap: 2rem
   }
 }

--- a/views/show.mcss
+++ b/views/show.mcss
@@ -2,13 +2,11 @@ DarkCrystalShow {
   font-family: sans, sans-serif, arial
 
   display: grid
-  grid-gap: .5rem
+  grid-gap: 1rem
+  align-content: start
 
   section.shards {
-    div.shard {
-      div.overview {
-        display: flex
-      }
-    }
+    display: grid
+    grid-gap: 1rem
   }
 }


### PR DESCRIPTION
@KGibb8 this is a pattern I haven't tried before but has been in my head.

What I've found is that making everything live and observeable and refreshing can be really painful. 
Observeables seem to be really sweet for simple things, and not so much large data structures. 

So the idea here is : 
- have a simple store which can trigger renders 
- do a single (non-live) fetch for data
- have a pull-stream listening for updates, and if there is one do that same fetch and process of data (rather than figuring out how to update your data store carefully!)

---

You had a question about _merging / collecting_ the related shards / requests / replies.
I did a thing where I built a new data structure I called `shardRecord` which looks like : 

```js
{ 
  shard: ShardMsg
  requests: Array,  // I made these Arrays because it's possible to send multiple requests with current setup
  replies: Array
}
```