### PR TITLE
update the others-shards page when a new request for a shard comes in

### DIFF
--- a/plugs/app/page/dark-crystal-index.js
+++ b/plugs/app/page/dark-crystal-index.js
@@ -42,7 +42,7 @@ exports.create = function (api) {
     const scuttle = Scuttle(api.sbot.obs.connection)
     const mode = Value(MINE)
 
-    return h('DarkCrystal -index', { title: '/dark-crystal' }, [
+    const page = h('DarkCrystal -index', { title: '/dark-crystal' }, [
       h('h1', [ 'Dark Crystal', h('i.fa.fa-diamond') ]),
       h('section.picker', [MINE, OTHERS].map(m => {
         return h('div', {
@@ -59,6 +59,9 @@ exports.create = function (api) {
         h('a', { href: '#', 'ev-click': goToMyRoots }, 'My roots')
       ])
     ])
+
+    page.scroll = () => {} // stops keyboard shortcuts from breaking
+    return page
   }
 
   function Mine ({ mode, scuttle }) {

--- a/plugs/app/page/dark-crystal-show.js
+++ b/plugs/app/page/dark-crystal-show.js
@@ -25,7 +25,7 @@ exports.create = function (api) {
     const scuttle = Scuttle(api.sbot.obs.connection)
     const { name } = getContent(location)
 
-    return h('DarkCrystal -show', { title: `/dark-crystal — ${name}` }, [
+    const page = h('DarkCrystal -show', { title: `/dark-crystal — ${name}` }, [
       h('h1', ['Dark Crystal', h('i.fa.fa-diamond')]),
       h('h2', name),
       DarkCrystalShow({
@@ -40,7 +40,10 @@ exports.create = function (api) {
           'ev-click': () => api.app.sync.goTo({ page: 'dark-crystal' }),
           'title': 'Back'
         })
-      ]),
+      ])
     ])
+
+    page.scroll = () => {} // stops keyboard shortcuts from breaking
+    return page
   }
 }

--- a/views/others-shards/index.js
+++ b/views/others-shards/index.js
@@ -126,8 +126,12 @@ function DarkCrystalFriendsIndex (opts) {
       pull.drain(m => getRecords())
     )
 
-    // TODO watch for others requests
-    // actually only watch requests...
+    // watch for others requests
+    pull(
+      scuttle.recover.pull.requests({ live: true, old: false }),
+      pull.filter(m => !m.sync),
+      pull.drain(m => getRecords())
+    )
   }
 }
 


### PR DESCRIPTION
updates : 
- ability for other shards page to self-update
- adds a dummy `scroll` function to pages to stop the keyboard shortcuts blowing up
  - this is an annoying hack fix, that system needs review