### PR TITLE
forward.async.publish now takes an object

### DIFF
--- a/views/forward/new.js
+++ b/views/forward/new.js
@@ -96,7 +96,7 @@ module.exports = function DarkCrystalForwardNew (opts) {
     pull(
       pull.values(shards),
       pull.map(shard => shard.root),
-      pull.asyncMap((root, cb) => scuttle.forward.async.publish(root, feedId, cb)),
+      pull.asyncMap((root, cb) => scuttle.forward.async.publish({ root, recp: feedId }, cb)),
       pull.collect((err, forwards) => {
         // TODO handle this better
         if (err) return console.err(err)


### PR DESCRIPTION
to fit with our convention with the other publish methods, `darkCrystal.forward.async.publish` now takes an object rather than separate arguments. 

we will need to bump the version of scuttle-dark-crystal in package.json once that is published